### PR TITLE
add fallbackYear to the YearFetchingError

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -11,6 +11,7 @@ async function standardExample() {
   } catch (error) {
     if (error instanceof YearFetchingError) {
       console.error("🚨 Failed to fetch year:", error.message);
+      console.log("🚨 Fallback year:", error.fallbackYear);
     }
   }
 }
@@ -23,6 +24,7 @@ async function enterpriseExample() {
   } catch (error) {
     if (error instanceof YearFetchingError) {
       console.error("🚨 Enterprise mode failed:", error.message);
+      console.log("🚨 Fallback year:", error.fallbackYear);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,18 @@ export interface YearResponseDTO {
 }
 
 export class YearFetchingError extends Error {
+  /** 
+   * ⚠️ This value comes from your device's clock, which could be set to 1985 
+   * for all we know. Not recommended for time travel calculations or determining 
+   * if you're eligible for senior citizen discounts.
+   * In case of mission-critical applications, please consult your local time wizard.
+   */
+  fallbackYear: number;
+
   constructor(message: string) {
     super(`🚨 Year Fetching Operation Failed: ${message}`);
     this.name = "YearFetchingError";
+    this.fallbackYear = new Date().getFullYear();
   }
 }
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -40,6 +40,7 @@ test("getFullYear throws YearFetchingError on network error", async (t: TestCont
       (error: unknown) => {
         assert.ok(error instanceof YearFetchingError);
         assert.ok(error.message.includes("Network error"));
+        assert.equal(error.fallbackYear, new Date().getFullYear());
         return true;
       }
     );
@@ -62,6 +63,7 @@ test("getFullYear throws YearFetchingError on bad HTTP status", async (t: TestCo
       (error: unknown) => {
         assert.ok(error instanceof YearFetchingError);
         assert.ok(error.message.includes("HTTP Status: 500"));
+        assert.equal(error.fallbackYear, new Date().getFullYear());
         return true;
       }
     );


### PR DESCRIPTION
# Add fallbackYear to YearFetchingError

## Changes
- Added `fallbackYear` property to `YearFetchingError` class that provides the local system year when API calls fail
- Property is initialized in the constructor using `new Date().getFullYear()`
- Added documentation noting potential reliability concerns with system clock-based fallback

## Why
When year fetching fails, applications need a fallback value to gracefully degrade. This change provides a local system-based fallback while clearly documenting the limitations of this approach.

## Example Usage
```typescript
try {
   const data = await getFullYear();
} catch (error) {
   if (error instanceof YearFetchingError) {
      console.log(`Using fallback year: ${error.fallbackYear}`);
   }
}
```


## Notes
- The fallback relies on the device's system clock which may be inaccurate
- For time-critical applications, additional validation or alternative fallback mechanisms should be considered