### PR TITLE
add feature to exit the app on failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.3",
       "license": "ISC",
       "devDependencies": {
-        "@types/node": "^22.10.3",
+        "@types/node": "^22.10.4",
         "ts-node": "^10.9.2",
         "tshy": "^3.0.2",
         "typescript": "^5.7.2"
@@ -103,9 +103,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.3.tgz",
-      "integrity": "sha512-DifAyw4BkrufCILvD3ucnuN8eydUfc/C1GlyrnI+LK6543w5/L3VeVgf05o3B4fqSXP1dKYLOZsKfutpxPzZrw==",
+      "version": "22.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.4.tgz",
+      "integrity": "sha512-99l6wv4HEzBQhvaU/UGoeBoCK61SCROQaCCGyQSgX2tEQ3rKkNZ2S7CEWnS/4s1LV+8ODdK21UeyR1fHP2mXug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "description": "An unofficial client for getfullyear.com",
   "devDependencies": {
-    "@types/node": "^22.10.3",
+    "@types/node": "^22.10.4",
     "ts-node": "^10.9.2",
     "tshy": "^3.0.2",
     "typescript": "^5.7.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ export class YearFetchingError extends Error {
  * @throws {YearFetchingError} When the year cannot be gracefully acquired
  */
 export default async function getFullYear(
-  isEnterprise: boolean = false
+  isEnterprise: boolean = false,
+  exitOnFailure: boolean = true,
 ): Promise<YearResponseDTO> {
   console.log(
     `🚀 Initiating year acquisition process ${
@@ -51,6 +52,14 @@ export default async function getFullYear(
     console.log(`✅ Year acquisition completed successfully`);
     return data;
   } catch (error) {
+    if (exitOnFailure) {
+      if (typeof process !== "undefined") {
+        process.exit(1);
+      } else if (typeof window !== "undefined") {
+        window.close();
+      }
+    }
+
     console.error(
       `❌ Catastrophic failure in year acquisition process: ${
         error instanceof Error ? error.message : "Unknown error"


### PR DESCRIPTION
In some cases when the fetch fails, its better not to continue and to instead exit the app. To accommodate this use-case we should add the ability to exit the app instantly when a failure is detected.